### PR TITLE
Refactor the salt to remove session_key/updated_utc

### DIFF
--- a/keg_auth/core.py
+++ b/keg_auth/core.py
@@ -275,7 +275,6 @@ def refresh_session_menus(app, user):
 
 
 def update_last_login(app, user):
-    # import pdb; pdb.set_trace()
     user.last_login_utc = arrow.utcnow()
     db.session.commit()
 

--- a/keg_auth/core.py
+++ b/keg_auth/core.py
@@ -6,6 +6,7 @@ from keg.signals import db_init_post
 import jinja2
 import sqlalchemy as sa
 import six
+import arrow
 
 import keg_auth.cli
 from keg_auth.libs.authenticators import KegAuthenticator
@@ -273,5 +274,16 @@ def refresh_session_menus(app, user):
         menu.clear_authorization(user.get_id())
 
 
-flask_login.signals.user_logged_in.connect(refresh_session_menus)
+def update_last_login(app, user):
+    # import pdb; pdb.set_trace()
+    user.last_login_utc = arrow.utcnow()
+    db.session.commit()
+
+
+def on_login(app, user):
+    refresh_session_menus(app, user)
+    update_last_login(app, user)
+
+
+flask_login.signals.user_logged_in.connect(on_login)
 flask_login.signals.user_logged_out.connect(refresh_session_menus)

--- a/keg_auth/model/__init__.py
+++ b/keg_auth/model/__init__.py
@@ -213,7 +213,7 @@ class UserMixin(object):
             self.display_value,
             str(self.is_active),
             self.password.hash.decode() if self.password is not None else '',
-            str(self.last_login_utc)
+            self.last_login_utc.to('UTC').isoformat() if self.last_login_utc else None
         ])
 
     def get_token_serializer(self, expires_in):

--- a/keg_auth/tests/test_auth_manager.py
+++ b/keg_auth/tests/test_auth_manager.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import flask
 import mock
-
 from keg_auth.core import AuthManager
 from keg_auth.libs.authenticators import KegAuthenticator, JwtRequestLoader
 

--- a/keg_auth/tests/test_core.py
+++ b/keg_auth/tests/test_core.py
@@ -9,8 +9,8 @@ class TestUpdateLastLogin(object):
 
     @freezegun.freeze_time("2018-10-01 15:00:00")
     def test_it_will_update_last_login(self):
-        u = ents.User.testing_create(email="test@bar.com", last_login_utc=None)
+        u = ents.User.testing_create(email=u"test@bar.com", last_login_utc=None)
         update_last_login(flask.current_app, u)
         ents.db.session.remove()
-        u = ents.User.get_by(email="test@bar.com")
+        u = ents.User.get_by(email=u"test@bar.com")
         assert u.last_login_utc == arrow.utcnow()

--- a/keg_auth/tests/test_core.py
+++ b/keg_auth/tests/test_core.py
@@ -1,0 +1,16 @@
+import flask
+import freezegun
+import arrow
+from keg_auth.core import update_last_login
+from keg_auth_ta.model import entities as ents
+
+
+class TestUpdateLastLogin(object):
+
+    @freezegun.freeze_time("2018-10-01 15:00:00")
+    def test_it_will_update_last_login(self):
+        u = ents.User.testing_create(email="test@bar.com", last_login_utc=None)
+        update_last_login(flask.current_app, u)
+        ents.db.session.remove()
+        u = ents.User.get_by(email="test@bar.com")
+        assert u.last_login_utc == arrow.utcnow()

--- a/keg_auth/tests/test_model.py
+++ b/keg_auth/tests/test_model.py
@@ -70,25 +70,19 @@ class TestUser(object):
 
     def test_token_salt_info_changed(self):
         def check_field(field, new_value):
-            # this can be tricky - the database will set our update timestamp, which will also kill
-            # a token. To test this, set what we expect to kill the token, then reset the update
-            # timestamp, so we're verifying the desired field
             user = ents.User.testing_create()
             token = user.token_generate()
             setattr(user, field, new_value)
             db.session.flush()
-            if field != 'updated_utc':
-                db.session.execute('update users set updated_utc = created_utc')
             db.session.commit()
             db.session.refresh(user)
             assert not user.token_verify(token)
 
-        check_field('session_key', 'foobar')
         check_field('email', 'foobar')
         check_field('is_enabled', False)
         check_field('is_verified', False)
         check_field('password', 'foobar')
-        check_field('updated_utc', arrow.get(datetime(2013, 5, 5)))
+        check_field('last_login_utc', arrow.utcnow())
 
     def test_token_expiration(self):
         user = ents.User.add(email='foo', password='bar')

--- a/keg_auth/tests/test_model.py
+++ b/keg_auth/tests/test_model.py
@@ -1,8 +1,5 @@
 # Using unicode_literals instead of adding 'u' prefix to all stings that go to SA.
 from __future__ import unicode_literals
-
-from datetime import datetime
-
 import arrow
 import flask
 from keg.db import db

--- a/keg_auth/tests/utils.py
+++ b/keg_auth/tests/utils.py
@@ -1,0 +1,47 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def listen_to(signal):
+    ''' Context Manager that listens to signals and records emissions
+    Example:
+    with listen_to(user_logged_in) as listener:
+        login_user(user)
+        # Assert that a single emittance of the specific args was seen.
+        listener.assert_heard_one(app, user=user))
+        # Of course, you can always just look at the list yourself
+        self.assertEqual(1, len(listener.heard))
+    '''
+    class _SignalsCaught(object):
+        def __init__(self):
+            self.heard = []
+
+        def add(self, *args, **kwargs):
+            ''' The actual handler of the signal. '''
+            self.heard.append((args, kwargs))
+
+        def assert_heard_one(self, *args, **kwargs):
+            ''' The signal fired once, and with the arguments given '''
+            if len(self.heard) == 0:
+                raise AssertionError('No signals were fired')
+            elif len(self.heard) > 1:
+                msg = '{0} signals were fired'.format(len(self.heard))
+                raise AssertionError(msg)
+            elif self.heard[0] != (args, kwargs):
+                msg = 'One signal was heard, but with incorrect arguments: '\
+                    'Got ({0}) expected ({1}, {2})'
+                raise AssertionError(msg.format(self.heard[0], args, kwargs))
+
+        def assert_heard_none(self, *args, **kwargs):
+            ''' The signal fired no times '''
+            if len(self.heard) >= 1:
+                msg = '{0} signals were fired'.format(len(self.heard))
+                raise AssertionError(msg)
+
+    results = _SignalsCaught()
+    signal.connect(results.add)
+
+    try:
+        yield results
+    finally:
+        signal.disconnect(results.add)

--- a/readme.rst
+++ b/readme.rst
@@ -348,3 +348,20 @@ accessible). Only a few changes are necessary from the examples above to achieve
 
 - leave `UserEmailMixin` out of the `User` model
 - do not specify a mail_manager when setting up `AuthManager`
+
+
+
+Email/Reset Password functionality
+------------------------------------
+
+* The JWT tokens in the email / reset password emails are salted with
+    * username/email (depends on which is enabled)
+    * password hash
+    * last login utc
+    * is_active (verified/enabled combination)
+
+    This allows for tokens to become invalidate anytime of the following happens:
+        * username/email changes
+        * password hash changes
+        * a user logs in (last login utc will be updated and invalidate the token)
+        * is active (depending on the model this is calculated from is_enabled/is_verified fields)


### PR DESCRIPTION
Added last login utc field so that we can now invalidate tokens
when a user logs in.

fixes gh-45