### PR TITLE
OIDC and related updates

### DIFF
--- a/keg_auth/forms.py
+++ b/keg_auth/forms.py
@@ -89,14 +89,6 @@ class GroupsMixin(object):
 
 
 class PermissionsMixin(object):
-    select_deselect_all = MultiCheckboxField(
-        'Bulk Permission Action (takes effect after submit)',
-        choices=(
-            ('select_all', 'Select All'),
-            ('deselect_all', 'Deselect All')
-        ),
-        render_kw={'class': 'list-unstyled', 'style': 'margin-bottom:0;'},
-    )
     permission_ids = MultiCheckboxField(
         'Permissions',
         render_kw={'class': 'list-unstyled'},
@@ -110,10 +102,6 @@ class PermissionsMixin(object):
 
     def get_selected_permissions(self):
         selected_ids = self.permission_ids.data
-        if 'select_all' in self.select_deselect_all.data:
-            selected_ids = [choice[0] for choice in self.permission_ids.choices]
-        elif 'deselect_all' in self.select_deselect_all.data:
-            selected_ids = []
         return entities_from_ids(flask.current_app.auth_manager.entity_registry.permission_cls,
                                  selected_ids)
 
@@ -170,7 +158,7 @@ def user_form(config=None, allow_superuser=False, endpoint='', fields=['is_enabl
             is_superuser = FieldMeta('Superuser')
             __default__ = FieldMeta
 
-        field_order = tuple(_fields + ['group_ids', 'bundle_ids', 'select_deselect_all',
+        field_order = tuple(_fields + ['group_ids', 'bundle_ids',
                                        'permission_ids'])
 
         setattr(FieldsMeta, username_key, FieldMeta(
@@ -197,18 +185,6 @@ def user_form(config=None, allow_superuser=False, endpoint='', fields=['is_enabl
         def obj(self):
             return self._obj
 
-        def validate(self):
-            if not ModelForm.validate(self):
-                return False
-
-            if 'select_all' in self.select_deselect_all.data and 'deselect_all' in self.select_deselect_all.data:  # noqa
-                error_list = list(self.select_deselect_all.errors)
-                error_list.append('You may not select all and deselect all. Please choose one.')
-                self.select_deselect_all.errors = tuple(error_list)
-                return False
-
-            return True
-
         def __iter__(self):
             order = ('csrf_token', ) + self.field_order
             return (getattr(self, field_id) for field_id in order)
@@ -224,7 +200,7 @@ def group_form(endpoint):
         return link_to(obj.name, flask.url_for(endpoint, objid=obj.id))
 
     class Group(PermissionsMixin, BundlesMixin, ModelForm):
-        _field_order = ('name', 'bundle_ids', 'select_deselect_all', 'permission_ids',)
+        _field_order = ('name', 'bundle_ids', 'permission_ids',)
 
         class Meta:
             model = group_cls
@@ -238,18 +214,6 @@ def group_form(endpoint):
         @property
         def obj(self):
             return self._obj
-
-        def validate(self):
-            if not ModelForm.validate(self):
-                return False
-
-            if 'select_all' in self.select_deselect_all.data and 'deselect_all' in self.select_deselect_all.data:   # noqa
-                error_list = list(self.select_deselect_all.errors)
-                error_list.append('You may not select all and deselect all. Please choose one.')
-                self.select_deselect_all.errors = tuple(error_list)
-                return False
-
-            return True
 
     return Group
 
@@ -274,17 +238,5 @@ def bundle_form(endpoint):
         @property
         def obj(self):
             return self._obj
-
-        def validate(self):
-            if not ModelForm.validate(self):
-                return False
-
-            if 'select_all' in self.select_deselect_all.data and 'deselect_all' in self.select_deselect_all.data:   # noqa
-                error_list = list(self.select_deselect_all.errors)
-                error_list.append('You may not select all and deselect all. Please choose one.')
-                self.select_deselect_all.errors = tuple(error_list)
-                return False
-
-            return True
 
     return Bundle

--- a/keg_auth/libs/authenticators.py
+++ b/keg_auth/libs/authenticators.py
@@ -496,7 +496,8 @@ class OidcLogoutViewResponder(LogoutViewResponder):
 
     def get(self):
         oidc = flask.current_app.auth_manager.oidc
-        url_after_login = flask.url_for(flask.current_app.auth_manager.endpoints['after-login'])
+        url_login = flask.url_for(flask.current_app.auth_manager.endpoint('login'))
+        url_after_login = flask.url_for(flask.current_app.auth_manager.endpoint('after-login'))
         bad_token_redirect_resp = flask.current_app.login_manager.unauthorized()
 
         """ Logout won't work if user isn't authenticated to begin with, i.e. there won't be a
@@ -506,7 +507,7 @@ class OidcLogoutViewResponder(LogoutViewResponder):
         except Exception as exc:
             if 'User was not authenticated' not in str(exc):
                 raise
-            return flask.abort(flask.redirect(url_after_login))
+            return flask.abort(flask.redirect(url_login))
 
         """ In some cases e.g. app restart, credentials store may not have valid information in the
             flask server-side info. In that case, clear the client token and refresh info from
@@ -565,7 +566,7 @@ class OidcAuthenticator(LoginAuthenticator):
         super().__init__(app)
 
     def verify_user(self, login_id=None):
-        user = self.user_ent.query().filter_by(username=login_id).one_or_none()
+        user = self.user_ent.query.filter_by(username=login_id).one_or_none()
 
         if not user:
             raise UserNotFound

--- a/keg_auth/libs/authenticators.py
+++ b/keg_auth/libs/authenticators.py
@@ -123,18 +123,21 @@ class UserResponderMixin(object):
 
     def on_inactive_user(self, user):
         if flask.current_app.auth_manager.mail_manager and not user.is_verified:
-            message, category = self.flash_unverified_user
-            flash(message.format(user.email), category)
+            if self.flash_unverified_user:
+                message, category = self.flash_unverified_user
+                flash(message.format(user.email), category)
         if not user.is_enabled:
             self.on_disabled_user(user)
 
     def on_invalid_user(self, username):
-        message, category = self.flash_invalid_user
-        flash(message.format(username), category)
+        if self.flash_invalid_user:
+            message, category = self.flash_invalid_user
+            flash(message.format(username), category)
 
     def on_disabled_user(self, user):
-        message, category = self.flash_disabled_user
-        flash(message.format(user.display_value), category)
+        if self.flash_disabled_user:
+            message, category = self.flash_disabled_user
+            flash(message.format(user.display_value), category)
 
 
 class LoginResponderMixin(UserResponderMixin):
@@ -159,7 +162,8 @@ class LoginResponderMixin(UserResponderMixin):
 
     def on_success(self, user):
         flask_login.login_user(user)
-        flash(*self.flash_success)
+        if self.flash_success:
+            flash(*self.flash_success)
 
         # support Flask-Login "next" parameter
         next_parameter = flask.request.values.get('next')
@@ -180,7 +184,8 @@ class FormResponderMixin(object):
     page_title = None
 
     def on_form_error(self, form):
-        flash(*self.flash_form_error)
+        if self.flash_form_error:
+            flash(*self.flash_form_error)
 
     def on_form_valid(self, form):
         raise NotImplementedError  # pragma: no cover
@@ -227,7 +232,8 @@ class PasswordSetterResponderBase(FormResponderMixin, ViewResponder):
         return super(PasswordSetterResponderBase, self).__call__(*args, **kwargs)
 
     def flash_and_redirect(self, flash_parts, auth_ident):
-        flash(*flash_parts)
+        if flash_parts:
+            flash(*flash_parts)
         redirect_to = flask.current_app.auth_manager.url_for(auth_ident)
         flask.abort(flask.redirect(redirect_to))
 
@@ -300,7 +306,8 @@ class PasswordFormViewResponder(LoginResponderMixin, FormResponderMixin, ViewRes
             self.on_invalid_password()
 
     def on_invalid_password(self):
-        flash(*self.flash_invalid_password)
+        if self.flash_invalid_password:
+            flash(*self.flash_invalid_password)
 
 
 class ForgotPasswordViewResponder(UserResponderMixin, FormResponderMixin, ViewResponder):
@@ -330,7 +337,8 @@ class ForgotPasswordViewResponder(UserResponderMixin, FormResponderMixin, ViewRe
 
     def on_success(self, user):
         self.send_email(user)
-        flash(*self.flash_success)
+        if self.flash_success:
+            flash(*self.flash_success)
         redirect_to = flask.current_app.auth_manager.url_for('after-forgot')
         return flask.redirect(redirect_to)
 
@@ -345,7 +353,8 @@ class LogoutViewResponder(ViewResponder):
 
     def get(self):
         flask_login.logout_user()
-        flash(*self.flash_success)
+        if self.flash_success:
+            flash(*self.flash_success)
         redirect_to = flask.current_app.auth_manager.url_for('after-logout')
         flask.abort(flask.redirect(redirect_to))
 

--- a/keg_auth/templates/keg_auth/flash-messages-only.html
+++ b/keg_auth/templates/keg_auth/flash-messages-only.html
@@ -1,0 +1,7 @@
+{% extends config.get('BASE_TEMPLATE') or config['KEGAUTH_BASE_TEMPLATE'] %}
+
+{% block title %}{{ page_title }} | {{ super() }}{% endblock %}
+
+{% block page_content %}
+    {# Show any flash messages. #}
+{% endblock %}

--- a/keg_auth/templates/keg_auth/form-base.html
+++ b/keg_auth/templates/keg_auth/form-base.html
@@ -1,3 +1,4 @@
+{% import 'keg_elements/forms/horizontal.html' as horizontal %}
 {% extends config.get('BASE_TEMPLATE') or config['KEGAUTH_BASE_TEMPLATE'] %}
 
 {% block title %}{{ page_title }} | {{ super() }}{% endblock %}
@@ -7,6 +8,7 @@
 {% if (use_select2 == true) %}
     {% include 'keg_auth/select2-scripts.html' %}
 {% endif %}
+{{ horizontal.custom_js() }}
 {% endblock %}
 
 {% block styles %}
@@ -14,6 +16,7 @@
 {% if (use_select2 == true) %}
     {% include 'keg_auth/select2-styles.html' %}
 {% endif %}
+{{ horizontal.custom_css() }}
 {% endblock %}
 
 {% block page_content %}

--- a/keg_auth/tests/test_views.py
+++ b/keg_auth/tests/test_views.py
@@ -556,53 +556,6 @@ class TestUserCrud(ViewTestBase):
         assert user.groups == [group_approve]
         assert user.bundles == [bundle_approve]
 
-    def test_add_select_all_permissions(self):
-        for i in range(3):
-            ents.Permission.testing_create()
-
-        resp = self.client.get('/users/add')
-
-        resp.form['email'] = 'select_all@test.com'
-        resp.form['select_deselect_all'] = ['select_all']
-
-        resp = resp.form.submit()
-        # import pdb; pdb.set_trace()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/users')
-        assert resp.flashes == [('success', 'Successfully created User')]
-
-        user = ents.User.get_by(email='select_all@test.com')
-        assert user.permissions == ents.Permission.query.all()
-
-    def test_add_deselect_all_permissions(self):
-        p1 = ents.Permission.testing_create()
-        p2 = ents.Permission.testing_create()
-
-        resp = self.client.get('/users/add')
-
-        resp.form['email'] = 'deselect_all@test.com'
-        resp.form['select_deselect_all'] = ['deselect_all']
-        resp.form['permission_ids'] = [p1.id, p2.id]
-
-        resp = resp.form.submit()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/users')
-        assert resp.flashes == [('success', 'Successfully created User')]
-
-        user = ents.User.get_by(email='deselect_all@test.com')
-        assert user.permissions == []
-
-    def test_select_and_deselect_throws_error(self):
-        resp = self.client.get('/users/add')
-
-        resp.form['email'] = 'select_and_deselect_all@test.com'
-        resp.form['select_deselect_all'] = ['select_all', 'deselect_all']
-
-        resp = resp.form.submit()
-        assert resp.flashes == [('error', 'Form errors detected.  Please see below for details.')]
-        assert resp.pyquery('#select_deselect_all').siblings('.help-block').text() ==\
-            'You may not select all and deselect all. Please choose one.'
-
     def test_resend_verification(self):
         self.current_user.is_verified = True
         self.current_user.permissions = ents.Permission.query.filter_by(token='auth-manage').all()
@@ -768,13 +721,12 @@ class TestUserCrud(ViewTestBase):
         assert resp.form['bundle_ids'].value == [str(obj.id) for obj in user_edit.bundles]
         all_permissions = [p.description or p.token for p in ents.Permission.query.all()]
         user_permissions = [p.description or p.token for p in user_edit.permissions]
-        listed_permissions = resp.pyquery('#permission_ids')('option')
+        listed_permissions = resp.pyquery('#permission_ids')('.custom-checkbox')
         assert len(listed_permissions) == len(all_permissions)
         for permission_list_item in listed_permissions:
-            assert permission_list_item.text in all_permissions
-            if permission_list_item.text in user_permissions:
-                assert 'selected' in permission_list_item.attrib
-        assert resp.pyquery('#select_deselect_all')
+            assert permission_list_item.find('label').text in all_permissions
+            if permission_list_item.find('label').text in user_permissions:
+                assert 'checked' in permission_list_item.find('input').attrib
         resp.form['email'] = 'foo@bar.baz'
         resp = resp.form.submit()
 
@@ -961,52 +913,6 @@ class TestGroupCrud(ViewTestBase):
         assert group.permissions == [perm_approve]
         assert group.bundles == [bundle_approve]
 
-    def test_add_select_all_permissions(self):
-        for i in range(3):
-            ents.Permission.testing_create()
-
-        resp = self.client.get('/groups/add')
-
-        resp.form['name'] = 'test adding a group with select all permissions'
-        resp.form['select_deselect_all'] = ['select_all']
-
-        resp = resp.form.submit()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/groups')
-        assert resp.flashes == [('success', 'Successfully created Group')]
-
-        group = ents.Group.get_by(name='test adding a group with select all permissions')
-        assert group.permissions == ents.Permission.query.all()
-
-    def test_add_deselect_all_permissions(self):
-        p1 = ents.Permission.testing_create()
-        p2 = ents.Permission.testing_create()
-
-        resp = self.client.get('/groups/add')
-
-        resp.form['name'] = 'test adding a group with deselect all permissions'
-        resp.form['select_deselect_all'] = ['deselect_all']
-        resp.form['permission_ids'] = [p1.id, p2.id]
-
-        resp = resp.form.submit()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/groups')
-        assert resp.flashes == [('success', 'Successfully created Group')]
-
-        group = ents.Group.get_by(name='test adding a group with deselect all permissions')
-        assert group.permissions == []
-
-    def test_select_and_deselect_throws_error(self):
-        resp = self.client.get('/groups/add')
-
-        resp.form['name'] = 'test adding a group with select and deselect all permissions'
-        resp.form['select_deselect_all'] = ['select_all', 'deselect_all']
-
-        resp = resp.form.submit()
-        assert resp.flashes == [('error', 'Form errors detected.  Please see below for details.')]
-        assert resp.pyquery('#select_deselect_all').siblings('.help-block').text() ==\
-            'You may not select all and deselect all. Please choose one.'
-
     def test_edit(self):
         group_edit = ents.Group.testing_create(bundles=[ents.Bundle.testing_create()],
                                                permissions=[ents.Permission.testing_create()])
@@ -1016,13 +922,12 @@ class TestGroupCrud(ViewTestBase):
         assert resp.form['bundle_ids'].value == [str(obj.id) for obj in group_edit.bundles]
         all_permissions = [p.description or p.token for p in ents.Permission.query.all()]
         user_permissions = [p.description or p.token for p in group_edit.permissions]
-        listed_permissions = resp.pyquery('#permission_ids')('option')
+        listed_permissions = resp.pyquery('#permission_ids')('.custom-checkbox')
         assert len(listed_permissions) == len(all_permissions)
         for permission_list_item in listed_permissions:
-            assert permission_list_item.text in all_permissions
-            if permission_list_item.text in user_permissions:
-                assert 'selected' in permission_list_item.attrib
-        assert resp.pyquery('#select_deselect_all')
+            assert permission_list_item.find('label').text in all_permissions
+            if permission_list_item.find('label').text in user_permissions:
+                assert 'checked' in permission_list_item.find('input').attrib
         resp.form['name'] = 'test editing a group'
         resp = resp.form.submit()
 
@@ -1137,52 +1042,6 @@ class TestBundleCrud(ViewTestBase):
         bundle = ents.Bundle.get_by(name='test adding a bundle')
         assert bundle.permissions == [perm_approve]
 
-    def test_add_select_all_permissions(self):
-        for i in range(3):
-            ents.Permission.testing_create()
-
-        resp = self.client.get('/bundles/add')
-
-        resp.form['name'] = 'test adding a bundle with select all permissions'
-        resp.form['select_deselect_all'] = ['select_all']
-
-        resp = resp.form.submit()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/bundles')
-        assert resp.flashes == [('success', 'Successfully created Bundle')]
-
-        bundle = ents.Bundle.get_by(name='test adding a bundle with select all permissions')
-        assert bundle.permissions == ents.Permission.query.all()
-
-    def test_add_deselect_all_permissions(self):
-        p1 = ents.Permission.testing_create()
-        p2 = ents.Permission.testing_create()
-
-        resp = self.client.get('/bundles/add')
-
-        resp.form['name'] = 'test adding a bundle with deselect all permissions'
-        resp.form['select_deselect_all'] = ['deselect_all']
-        resp.form['permission_ids'] = [p1.id, p2.id]
-
-        resp = resp.form.submit()
-        assert resp.status_code == 302
-        assert resp.location.endswith('/bundles')
-        assert resp.flashes == [('success', 'Successfully created Bundle')]
-
-        bundle = ents.Bundle.get_by(name='test adding a bundle with deselect all permissions')
-        assert bundle.permissions == []
-
-    def test_select_and_deselect_throws_error(self):
-        resp = self.client.get('/bundles/add')
-
-        resp.form['name'] = 'test adding a bundle with select and deselect all permissions'
-        resp.form['select_deselect_all'] = ['select_all', 'deselect_all']
-
-        resp = resp.form.submit()
-        assert resp.flashes == [('error', 'Form errors detected.  Please see below for details.')]
-        assert resp.pyquery('#select_deselect_all').siblings('.help-block').text() ==\
-            'You may not select all and deselect all. Please choose one.'
-
     def test_edit(self):
         bundle_edit = ents.Bundle.testing_create(permissions=[ents.Permission.testing_create()])
 
@@ -1190,13 +1049,12 @@ class TestBundleCrud(ViewTestBase):
         assert resp.form['name'].value == bundle_edit.name
         all_permissions = [p.description or p.token for p in ents.Permission.query.all()]
         user_permissions = [p.description or p.token for p in bundle_edit.permissions]
-        listed_permissions = resp.pyquery('#permission_ids')('option')
+        listed_permissions = resp.pyquery('#permission_ids')('.custom-checkbox')
         assert len(listed_permissions) == len(all_permissions)
         for permission_list_item in listed_permissions:
-            assert permission_list_item.text in all_permissions
-            if permission_list_item.text in user_permissions:
-                assert 'selected' in permission_list_item.attrib
-        assert resp.pyquery('#select_deselect_all')
+            assert permission_list_item.find('label').text in all_permissions
+            if permission_list_item.find('label').text in user_permissions:
+                assert 'checked' in permission_list_item.find('input').attrib
         resp.form['name'] = 'test editing a bundle'
         resp = resp.form.submit()
 

--- a/keg_auth/tests/test_views.py
+++ b/keg_auth/tests/test_views.py
@@ -1,5 +1,6 @@
 #s Using unicode_literals instead of adding 'u' prefix to all stings that go to SA.
 from __future__ import unicode_literals
+from blazeutils.datastructures import BlankObject
 import flask
 import freezegun
 import arrow
@@ -1238,3 +1239,107 @@ class TestFormSelect2(ViewTestBase):
         resp = self.client.get('/users/add')
         assert self.script not in resp
         assert self.style not in resp
+
+
+@pytest.fixture
+def auth_user():
+    user = ents.User.testing_create()
+    yield user
+
+
+@pytest.fixture
+def oidc_client():
+    client = AuthTestApp(flask.current_app)
+
+    with mock.patch.dict(
+        flask.current_app.config,
+        {
+            'OIDC_CLIENT_SECRETS': 'notreallyneeded',
+            'OIDC_COOKIE_SECURE': False,
+            'OIDC_CALLBACK_ROUTE': '/oidc/callback',
+            'OIDC_SCOPES': ('openid', 'email', 'profile'),
+            'OIDC_REDIRECT_BASE': 'http://localhost:5000',
+            'OIDC_LOGOUT': '/oauth2/default/v1/logout',
+            'OIDC_PROVIDER_URL': 'https://the.provider',
+            'OIDC_CLIENT_ID': 'theproviderclientid',
+            'OIDC_CLIENT_SECRET': 'supersecretrandomgeneratedstring',
+        }
+    ):
+        from keg_auth.libs.authenticators import OidcAuthenticator
+
+        # clean up app so OIDC can set up again
+        flask.current_app._got_first_request = False
+        flask.current_app.view_functions.pop('_oidc_callback', None)
+
+        # set up OIDC handler and attach it to the app
+        authenticator = OidcAuthenticator(flask.current_app)
+
+        with mock.patch.object(
+            flask.current_app.auth_manager,
+            'login_authenticator',
+            authenticator
+        ):
+            yield client
+
+
+@pytest.fixture
+def oidc_auth_client(oidc_client, auth_user):
+    username = auth_user.username
+
+    def _token_setter():
+        flask.g.oidc_id_token = 'foobar'
+
+    def _field_getter(fieldname):
+        return username
+
+    with mock.patch.dict(
+        flask.current_app.auth_manager.oidc.__dict__,
+        {
+            'authenticate_or_redirect': _token_setter,
+            'user_getfield': _field_getter,
+        },
+    ):
+        yield oidc_client
+
+
+class TestOidcLogin:
+    def test_authenticated(self, oidc_auth_client):
+        resp = oidc_auth_client.get('/login', status=302)
+        assert resp.location == 'http://keg.example.com/'
+
+    def test_inactive(self, oidc_auth_client, auth_user):
+        ents.User.edit(auth_user.id, is_enabled=False)
+        resp = oidc_auth_client.get('/login', status=200)
+        assert 'has been disabled' in resp
+
+    def test_not_exists(self, oidc_auth_client):
+        ents.User.delete_cascaded()
+        resp = oidc_auth_client.get('/login', status=200)
+        assert 'No user account matches' in resp
+
+    def test_unauthenticated(self, oidc_client):
+        resp = oidc_client.get('/login', status=302)
+        assert 'oauth2/default/v1/authorize?' in resp.location
+
+
+class TestOidcLogout:
+    def test_unauthenticated(self, oidc_client):
+        resp = oidc_client.get('/logout', status=302)
+        assert resp.location == 'http://keg.example.com/login'
+
+    def test_bad_token(self, oidc_auth_client):
+        resp = oidc_auth_client.get('/logout', status=302)
+        assert resp.location == 'http://keg.example.com/login?next=%2Flogout'
+
+    def test_success(self, oidc_auth_client, auth_user):
+        with mock.patch.object(
+            flask.current_app.auth_manager.oidc,
+            'credentials_store',
+            {auth_user.username: 'bar'},
+        ), mock.patch(
+            'oauth2client.client.OAuth2Credentials.from_json',
+            lambda _: BlankObject(token_response={'id_token': 'foo'})
+        ):
+            resp = oidc_auth_client.get('/logout', status=302)
+            assert '/oauth2/default/v1/logout?id_token_hint=foo&post_logout_redirect_uri' \
+                in resp.location

--- a/keg_auth/views.py
+++ b/keg_auth/views.py
@@ -472,6 +472,7 @@ class Permission(keg.web.BaseView):
         return flask.render_template(
             self.grid_template,
             page_title=_('Permissions'),
+            page_heading=_('Permissions'),
             grid=grid
         )
 

--- a/keg_auth/views.py
+++ b/keg_auth/views.py
@@ -481,7 +481,7 @@ def make_blueprint(import_name, _auth_manager, bp_name='auth', login_cls=Login,
                    forgot_cls=ForgotPassword, reset_cls=ResetPassword, logout_cls=Logout,
                    verify_cls=VerifyAccount, user_crud_cls=User, group_crud_cls=Group,
                    bundle_crud_cls=Bundle, permission_cls=Permission,
-                   blueprint_class=flask.Blueprint):
+                   blueprint_class=flask.Blueprint, **kwargs):
     """ Blueprint factory for keg-auth views
 
         Naming the blueprint here requires us to create separate view classes so that the routes
@@ -494,7 +494,7 @@ def make_blueprint(import_name, _auth_manager, bp_name='auth', login_cls=Login,
         blueprint_class is the class to be instantiated as the Flask blueprint for auth views. The
         default is flask.blueprint, but a custom blueprint may be provided.
     """
-    _blueprint = blueprint_class(bp_name, import_name)
+    _blueprint = blueprint_class(bp_name, import_name, **kwargs)
 
     # It's not ideal we have to redefine the classes, but it's needed because of how
     # Keg.web.BaseView does it's meta programming.  If we don't redefine the class, then

--- a/keg_auth/views.py
+++ b/keg_auth/views.py
@@ -499,36 +499,45 @@ def make_blueprint(import_name, _auth_manager, bp_name='auth', login_cls=Login,
     # It's not ideal we have to redefine the classes, but it's needed because of how
     # Keg.web.BaseView does it's meta programming.  If we don't redefine the class, then
     # the view doesn't actually get created on blueprint.
-    class Login(login_cls):
-        blueprint = _blueprint
-        auth_manager = _auth_manager
+    if login_cls:
+        class Login(login_cls):
+            blueprint = _blueprint
+            auth_manager = _auth_manager
 
-    class ForgotPassword(forgot_cls):
-        blueprint = _blueprint
-        auth_manager = _auth_manager
+    if forgot_cls:
+        class ForgotPassword(forgot_cls):
+            blueprint = _blueprint
+            auth_manager = _auth_manager
 
-    class ResetPassword(reset_cls):
-        blueprint = _blueprint
-        auth_manager = _auth_manager
+    if reset_cls:
+        class ResetPassword(reset_cls):
+            blueprint = _blueprint
+            auth_manager = _auth_manager
 
-    class VerifyAccount(verify_cls):
-        blueprint = _blueprint
-        auth_manager = _auth_manager
+    if verify_cls:
+        class VerifyAccount(verify_cls):
+            blueprint = _blueprint
+            auth_manager = _auth_manager
 
-    class Logout(logout_cls):
-        blueprint = _blueprint
-        auth_manager = _auth_manager
+    if logout_cls:
+        class Logout(logout_cls):
+            blueprint = _blueprint
+            auth_manager = _auth_manager
 
-    class User(user_crud_cls):
-        blueprint = _blueprint
+    if user_crud_cls:
+        class User(user_crud_cls):
+            blueprint = _blueprint
 
-    class Group(group_crud_cls):
-        blueprint = _blueprint
+    if group_crud_cls:
+        class Group(group_crud_cls):
+            blueprint = _blueprint
 
-    class Bundle(bundle_crud_cls):
-        blueprint = _blueprint
+    if bundle_crud_cls:
+        class Bundle(bundle_crud_cls):
+            blueprint = _blueprint
 
-    class Permission(permission_cls):
-        blueprint = _blueprint
+    if permission_cls:
+        class Permission(permission_cls):
+            blueprint = _blueprint
 
     return _blueprint

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             'flask-bootstrap',
             'flask-jwt-extended',
             'flask-mail',
+            'flask-oidc',
             'flask-webtest',
             'freezegun',
             'mock',
@@ -76,6 +77,9 @@ setup(
         ],
         'mail': [
             'Flask-Mail',
-        ]
+        ],
+        'oidc': [
+            'flask-oidc',
+        ],
     }
 )


### PR DESCRIPTION
Allows using OIDC to connect with Okta (or any other OIDC-enabled provider) for login information.

Other updates along the way:
- fix missing page header for Permissions view
- allow passing blueprint kwargs to make_blueprint
- easier disabling of specific auth views
- allow view responder flash messages to be disabled
- drop bulk permission controls, since keg-elements takes care of that now

fixes #8