### PR TITLE
Flask Login update breaks tests

### DIFF
--- a/keg_auth/testing.py
+++ b/keg_auth/testing.py
@@ -437,7 +437,7 @@ class AuthTests(object):
         user = self.user_ent.testing_create(permissions=self.protected_url_permissions)
         client = flask_webtest.TestApp(flask.current_app)
         with client.session_transaction() as sess:
-            sess['user_id'] = user.session_key
+            sess['_user_id'] = user.session_key
 
         # Make sure our client is actually logged in
         client.get(self.protected_url, status=200)

--- a/keg_auth/tests/test_views.py
+++ b/keg_auth/tests/test_views.py
@@ -57,7 +57,7 @@ class TestViews(object):
 
         user = ents.User.testing_create()
         with client.session_transaction() as sess:
-            sess['user_id'] = user.session_key
+            sess['_user_id'] = user.session_key
 
         resp = client.get('/')
         assert '/login' not in resp

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'bcrypt',
         'commonmark',
 
-        'Flask-Login==0.4.1',
+        'Flask-Login',
         'Keg>=0.8.1',
         'KegElements>=0.5.21',
         'inflect',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'bcrypt',
         'commonmark',
 
-        'Flask-Login',
+        'Flask-Login>0.4.1',
         'Keg>=0.8.1',
         'KegElements>=0.5.21',
         'inflect',


### PR DESCRIPTION
Fixes #101 

This actually turned out to be incredibly simple. I started by looking at the commit linked in the issue, which ended up being a bad idea. A quick glance at the Flask-Login changelog shows:
> - Prefix authenticated user_id, remember, and remember_seconds in Flask Session
  with underscores to prevent accidental usage in application code. #470

All that was needed was adding an underscore to `user_id` when setting that property on the session to "manually" log in a user to flask-login. Worth noting that the Flask-Login update will break any tests in projects that attempt to set `user_id` (or any of the other changed keys) to the session manually. The fix is to simply change `user_id` to `_user_id`.