### PR TITLE
Fix RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.13"
+  commands:
+    - pip install uv
+    - uv pip install --system tox-uv
+    - tox -e docs
+    - mkdir -p $READTHEDOCS_OUTPUT/html
+    - cp -av docs/build/html/ $READTHEDOCS_OUTPUT


### PR DESCRIPTION
fixes #188

The RTD build is still failing due to problems building the LDAP module.  Why we need the LDAP module to build the docs is beyond me.  Leaving it for now because I don't want to spend time on this right now.  Thought it would be a quick fix.  