### PR TITLE
replace passlib usage with backwards-compatible hash comparisons

### DIFF
--- a/keg_auth/core.py
+++ b/keg_auth/core.py
@@ -97,12 +97,17 @@ class AuthManager(object):
     def init_config(self, app):
         """Provide app config defaults for crypto, mail, logins, etc."""
         _cc_kwargs = dict(schemes=DEFAULT_CRYPTO_SCHEMES, deprecated='auto')
-        legacy_kwargs = app.config.get('PASSLIB_CRYPTCONTEXT_KWARGS')
-        app.config.setdefault('KEGAUTH_PASSWORD_CONTEXT_KWARGS', legacy_kwargs or _cc_kwargs)
-        app.config.setdefault(
-            'PASSLIB_CRYPTCONTEXT_KWARGS',
-            app.config['KEGAUTH_PASSWORD_CONTEXT_KWARGS'],
-        )
+        legacy_cc_kwargs = app.config.get('PASSLIB_CRYPTCONTEXT_KWARGS')
+        config_cc_kwargs = app.config.get('KEGAUTH_PASSWORD_CONTEXT_KWARGS')
+
+        if legacy_cc_kwargs and not config_cc_kwargs:
+            raise Exception(
+                'Use KEGAUTH_PASSWORD_CONTEXT_KWARGS to configure schemes used '
+                'for hashing passwords. PASSLIB_CRYPTCONTEXT_KWARGS is no longer '
+                'supported in keg-auth.'
+            )
+
+        app.config.setdefault('KEGAUTH_PASSWORD_CONTEXT_KWARGS', _cc_kwargs)
 
         # config flag controls email ops such as sending verification emails, etc.
         # Note: model mixin must be in place for email

--- a/keg_auth/core.py
+++ b/keg_auth/core.py
@@ -97,7 +97,12 @@ class AuthManager(object):
     def init_config(self, app):
         """Provide app config defaults for crypto, mail, logins, etc."""
         _cc_kwargs = dict(schemes=DEFAULT_CRYPTO_SCHEMES, deprecated='auto')
-        app.config.setdefault('PASSLIB_CRYPTCONTEXT_KWARGS', _cc_kwargs)
+        legacy_kwargs = app.config.get('PASSLIB_CRYPTCONTEXT_KWARGS')
+        app.config.setdefault('KEGAUTH_PASSWORD_CONTEXT_KWARGS', legacy_kwargs or _cc_kwargs)
+        app.config.setdefault(
+            'PASSLIB_CRYPTCONTEXT_KWARGS',
+            app.config['KEGAUTH_PASSWORD_CONTEXT_KWARGS'],
+        )
 
         # config flag controls email ops such as sending verification emails, etc.
         # Note: model mixin must be in place for email

--- a/keg_auth/libs/authenticators.py
+++ b/keg_auth/libs/authenticators.py
@@ -4,7 +4,6 @@ from urllib.parse import urljoin, urlparse
 import arrow
 import flask
 import flask_login
-import passlib
 import sqlalchemy as sa
 import string
 import typing
@@ -17,6 +16,7 @@ from keg_auth import forms
 from keg_auth.extensions import flash, lazy_gettext as _
 from keg_auth.libs import get_domain_from_email
 from keg_auth.model import get_username_key, get_username
+from keg_auth.model.passwords import UnknownHashError
 from keg_auth.model.entity_registry import RegistryError
 
 try:
@@ -938,7 +938,7 @@ class KegAuthenticator(PasswordAuthenticatorMixin, LoginAuthenticator):
     def verify_password(self, user, password):
         try:
             return user.password == password
-        except passlib.exc.UnknownHashError:
+        except UnknownHashError:
             return False
 
 

--- a/keg_auth/model/__init__.py
+++ b/keg_auth/model/__init__.py
@@ -36,8 +36,6 @@ def registry():
 
 def _create_password_context_kwargs(**column_kwargs):
     config = flask.current_app.config.get('KEGAUTH_PASSWORD_CONTEXT_KWARGS')
-    if config is None:
-        config = flask.current_app.config['PASSLIB_CRYPTCONTEXT_KWARGS']
     retval = {}
     retval.update(config)
     retval.update(column_kwargs)

--- a/keg_auth/model/__init__.py
+++ b/keg_auth/model/__init__.py
@@ -16,15 +16,14 @@ from blazeutils import tolist
 from blazeutils.strings import randchars
 from keg.db import db
 from keg_elements.db.mixins import might_commit, might_flush
-from sqlalchemy.dialects import mssql
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy_utils import (
     ArrowType,
     EmailType,
-    PasswordType,
     force_auto_coercion,
 )
 
+from keg_auth.model.passwords import KAPasswordType, UnknownHashError
 from keg_auth.model.types import AttemptType
 from keg_auth.model.utils import generate_password
 
@@ -35,8 +34,10 @@ def registry():
     return flask.current_app.auth_manager.entity_registry
 
 
-def _create_cryptcontext_kwargs(**column_kwargs):
-    config = flask.current_app.config['PASSLIB_CRYPTCONTEXT_KWARGS']
+def _create_password_context_kwargs(**column_kwargs):
+    config = flask.current_app.config.get('KEGAUTH_PASSWORD_CONTEXT_KWARGS')
+    if config is None:
+        config = flask.current_app.config['PASSLIB_CRYPTCONTEXT_KWARGS']
     retval = {}
     retval.update(config)
     retval.update(column_kwargs)
@@ -51,13 +52,6 @@ class InvalidToken(Exception):
     pass
 
 
-class KAPasswordType(PasswordType):
-    def load_dialect_impl(self, dialect):
-        if dialect.name == 'mssql':
-            return mssql.VARCHAR(self.length)
-        return super(KAPasswordType, self).load_dialect_impl(dialect)
-
-
 class UserMixin(object):
     """Generic mixin for user entities."""
     # These two attributes are needed by Flask-Login.
@@ -66,7 +60,7 @@ class UserMixin(object):
 
     is_enabled = sa.Column(sa.Boolean, nullable=False, default=True)
     is_superuser = sa.Column(sa.Boolean, nullable=False, default=False)
-    password = sa.Column(KAPasswordType(onload=_create_cryptcontext_kwargs))
+    password = sa.Column(KAPasswordType(onload=_create_password_context_kwargs))
 
     username = sa.Column(sa.Unicode(512), nullable=False, unique=True)
 
@@ -354,7 +348,7 @@ class UserMixin(object):
 
 class UserTokenMixin(object):
     """Mixin for users who will be authenticated by tokens."""
-    token = sa.Column(KAPasswordType(onload=_create_cryptcontext_kwargs))
+    token = sa.Column(KAPasswordType(onload=_create_password_context_kwargs))
 
     @classmethod
     def generate_raw_auth_token(cls, length=32):
@@ -384,10 +378,13 @@ class UserTokenMixin(object):
             return
 
         user = cls.query.filter_by(email=real_email).one_or_none()
-        if user is None or not user.token.context.verify(raw_token, user.token.hash):
+        try:
+            if user is None or not user.token.context.verify(raw_token, user.token.hash):
+                return
+        except UnknownHashError:
             return
-        else:
-            return user
+
+        return user
 
     def reset_auth_token(self, **kwargs):
         """Reset the authentication token for this user
@@ -401,7 +398,10 @@ class UserTokenMixin(object):
         if not token or not self.token:
             return False
 
-        return self.token.context.verify(token, self.token.hash)
+        try:
+            return self.token.context.verify(token, self.token.hash)
+        except UnknownHashError:
+            return False
 
     def generate_api_token(self, token=None):
         raw_token = token or self.reset_auth_token()

--- a/keg_auth/model/passwords.py
+++ b/keg_auth/model/passwords.py
@@ -1,0 +1,378 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import os
+import weakref
+
+import bcrypt
+from sqlalchemy import types
+from sqlalchemy.dialects import oracle, postgresql, sqlite
+from sqlalchemy.ext.mutable import Mutable
+
+from sqlalchemy_utils.types.scalar_coercible import ScalarCoercible
+
+
+PBKDF2_SHA256_PREFIX = '$pbkdf2-sha256$'
+DEFAULT_BCRYPT_ROUNDS = 12
+DEFAULT_PBKDF2_SHA256_ROUNDS = 29000
+SUPPORTED_SCHEMES = ('bcrypt', 'pbkdf2_sha256', 'plaintext')
+_AB64_ENCODE_TRANS = str.maketrans('+/', './')
+_AB64_DECODE_TRANS = str.maketrans('./', '+/')
+
+
+class UnknownHashError(ValueError):
+    pass
+
+
+def _secret_to_bytes(secret):
+    if isinstance(secret, bytes):
+        return secret
+    if isinstance(secret, str):
+        return secret.encode('utf8')
+    raise TypeError(f'Unsupported secret type: {type(secret)!r}')
+
+
+def _secret_to_text(secret):
+    if isinstance(secret, str):
+        return secret
+    if isinstance(secret, bytes):
+        return secret.decode('utf8')
+    raise TypeError(f'Unsupported secret type: {type(secret)!r}')
+
+
+def _hash_to_text(password_hash):
+    if isinstance(password_hash, bytes):
+        return password_hash.decode('utf8')
+    if isinstance(password_hash, str):
+        return password_hash
+    raise TypeError(f'Unsupported hash type: {type(password_hash)!r}')
+
+
+def _ab64_encode(raw):
+    return base64.b64encode(raw).decode('ascii').rstrip('=').translate(_AB64_ENCODE_TRANS)
+
+
+def _ab64_decode(encoded):
+    translated = encoded.translate(_AB64_DECODE_TRANS)
+    padding = '=' * (-len(translated) % 4)
+    return base64.b64decode(translated + padding)
+
+
+class PasswordHash(Mutable):
+    @classmethod
+    def coerce(cls, key, value):
+        if isinstance(value, PasswordHash):
+            return value
+
+        if isinstance(value, (str, bytes)):
+            return cls(value, secret=True)
+
+        return super().coerce(key, value)
+
+    def __init__(self, value, context=None, secret=False):
+        self.hash = value if not secret else None
+        self.secret = value if secret else None
+
+        if isinstance(self.hash, str):
+            self.hash = self.hash.encode('utf8')
+
+        self.context = weakref.proxy(context) if context is not None else None
+
+    def __eq__(self, value):
+        if self.hash is None or value is None:
+            return self.hash is value
+
+        if isinstance(value, PasswordHash):
+            # This is not the normal authentication path, but keep the fallback comparison
+            # constant-time so we don't introduce an avoidable timing side channel.
+            return hmac.compare_digest(value.hash, self.hash)
+
+        if self.context is None:
+            return value == self
+
+        if isinstance(value, (str, bytes)):
+            valid, new = self.context.verify_and_update(value, self.hash)
+            if valid and new:
+                self.hash = new.encode('utf8') if isinstance(new, str) else new
+                self.changed()
+            return valid
+
+        return False
+
+    def __ne__(self, value):
+        return not (self == value)
+
+
+class PasswordContext:
+    def __init__(self, schemes, deprecated='auto', **kwargs):
+        if not schemes:
+            raise ValueError('At least one password scheme is required')
+
+        unknown = set(schemes) - set(SUPPORTED_SCHEMES)
+        if unknown:
+            raise ValueError(f'Unsupported password schemes: {sorted(unknown)!r}')
+
+        self._schemes = tuple(schemes)
+        self._preferred_scheme = self._schemes[0]
+        self._deprecated = self._build_deprecated_set(deprecated)
+        self.bcrypt_rounds = kwargs.get('bcrypt__rounds', DEFAULT_BCRYPT_ROUNDS)
+        self.pbkdf2_sha256_rounds = kwargs.get(
+            'pbkdf2_sha256__rounds',
+            DEFAULT_PBKDF2_SHA256_ROUNDS,
+        )
+
+    def _build_deprecated_set(self, deprecated):
+        if deprecated == 'auto':
+            return set(self._schemes[1:])
+        if deprecated is None:
+            return set()
+        if isinstance(deprecated, str):
+            return {deprecated}
+        return set(deprecated)
+
+    def schemes(self):
+        return self._schemes
+
+    def hash(self, secret):
+        return self._hash_with_scheme(secret, self._select_hash_scheme(secret))
+
+    def verify(self, secret, password_hash):
+        valid, _ = self.verify_and_update(secret, password_hash)
+        return valid
+
+    def verify_and_update(self, secret, password_hash):
+        password_hash = _hash_to_text(password_hash)
+        scheme = self._identify_scheme(password_hash)
+        valid, legacy_truncation = self._verify(secret, password_hash, scheme)
+        if not valid:
+            return False, None
+
+        target_scheme = self._select_hash_scheme(secret)
+        # Mirror passlib/sqlalchemy-utils semantics: successful verification may yield a
+        # replacement hash when the stored value uses a deprecated scheme or outdated
+        # parameters. Callers using PasswordHash.__eq__ will transparently store that new
+        # hash back onto the wrapped object.
+        if self._needs_update(password_hash, scheme, target_scheme, legacy_truncation):
+            return True, self._hash_with_scheme(secret, target_scheme)
+
+        return True, None
+
+    def _select_hash_scheme(self, secret):
+        secret_bytes = _secret_to_bytes(secret)
+        for scheme in self._schemes:
+            # bcrypt only covers the first 72 bytes of a secret. For new hashes, do not create
+            # a bcrypt hash for longer input; prefer the next configured scheme that can cover
+            # the entire secret.
+            if scheme != 'bcrypt' or len(secret_bytes) <= 72:
+                return scheme
+        raise ValueError('No configured password scheme can hash the supplied secret')
+
+    def _identify_scheme(self, password_hash):
+        # Identify the stored hash format from its serialized prefix. We only support the
+        # formats we generate or have historically generated through passlib.
+        if password_hash.startswith(('$2a$', '$2b$', '$2y$')):
+            return 'bcrypt'
+        if password_hash.startswith(PBKDF2_SHA256_PREFIX):
+            return 'pbkdf2_sha256'
+        if 'plaintext' in self._schemes:
+            return 'plaintext'
+        raise UnknownHashError('Unrecognized password hash format')
+
+    def _verify(self, secret, password_hash, scheme):
+        if scheme == 'bcrypt':
+            secret_bytes = _secret_to_bytes(secret)
+            if len(secret_bytes) > 72:
+                # Legacy bcrypt inputs only authenticate against the first 72 bytes. Preserve
+                # that behavior conservatively for compatibility with hashes that may have been
+                # created when longer input was silently truncated. We intentionally do not
+                # rehash on success because we cannot prove the bytes after 72 were ever part of
+                # the original effective secret.
+                return (
+                    bcrypt.checkpw(secret_bytes[:72], password_hash.encode('ascii')),
+                    True,
+                )
+
+            try:
+                return bcrypt.checkpw(secret_bytes, password_hash.encode('ascii')), False
+            except ValueError:
+                return False, False
+
+        if scheme == 'pbkdf2_sha256':
+            return self._verify_pbkdf2_sha256(secret, password_hash), False
+
+        if scheme == 'plaintext':
+            return (
+                hmac.compare_digest(_secret_to_bytes(secret), password_hash.encode('utf8')),
+                False,
+            )
+
+        raise UnknownHashError(f'Unsupported password scheme: {scheme}')
+
+    def _needs_update(self, password_hash, current_scheme, target_scheme, legacy_truncation):
+        if legacy_truncation:
+            # Do not auto-upgrade legacy bcrypt hashes that only matched after truncating the
+            # presented secret. Upgrading would incorrectly assume the bytes after the first 72
+            # were part of the original intended secret.
+            return False
+
+        if current_scheme != target_scheme or current_scheme in self._deprecated:
+            return True
+
+        if current_scheme == 'bcrypt':
+            return self._bcrypt_rounds(password_hash) != self.bcrypt_rounds
+
+        if current_scheme == 'pbkdf2_sha256':
+            return self._pbkdf2_rounds(password_hash) != self.pbkdf2_sha256_rounds
+
+        return False
+
+    def _hash_with_scheme(self, secret, scheme):
+        if scheme == 'bcrypt':
+            return bcrypt.hashpw(
+                _secret_to_bytes(secret),
+                bcrypt.gensalt(rounds=self.bcrypt_rounds),
+            ).decode('ascii')
+
+        if scheme == 'pbkdf2_sha256':
+            # Keep the on-disk format compatible with passlib's pbkdf2_sha256 encoding so
+            # existing hashes remain verifiable and successful auth can migrate them forward.
+            salt = os.urandom(16)
+            checksum = hashlib.pbkdf2_hmac(
+                'sha256',
+                _secret_to_bytes(secret),
+                salt,
+                self.pbkdf2_sha256_rounds,
+            )
+            return (
+                f'{PBKDF2_SHA256_PREFIX}{self.pbkdf2_sha256_rounds}$'
+                f'{_ab64_encode(salt)}${_ab64_encode(checksum)}'
+            )
+
+        if scheme == 'plaintext':
+            return _secret_to_text(secret)
+
+        raise UnknownHashError(f'Unsupported password scheme: {scheme}')
+
+    def _verify_pbkdf2_sha256(self, secret, password_hash):
+        rounds = self._pbkdf2_rounds(password_hash)
+        try:
+            _, _, rounds_str, salt_encoded, checksum_encoded = password_hash.split('$')
+            if rounds_str != str(rounds):
+                return False
+            salt = _ab64_decode(salt_encoded)
+            checksum = _ab64_decode(checksum_encoded)
+        except (ValueError, binascii.Error) as exc:
+            raise UnknownHashError('Invalid pbkdf2_sha256 hash format') from exc
+
+        calculated = hashlib.pbkdf2_hmac(
+            'sha256',
+            _secret_to_bytes(secret),
+            salt,
+            rounds,
+            len(checksum),
+        )
+        # Compare the derived checksum in constant time; this is the actual authentication check
+        # for stored pbkdf2 hashes.
+        return hmac.compare_digest(calculated, checksum)
+
+    def _bcrypt_rounds(self, password_hash):
+        try:
+            return int(password_hash.split('$')[2])
+        except (IndexError, ValueError) as exc:
+            raise UnknownHashError('Invalid bcrypt hash format') from exc
+
+    def _pbkdf2_rounds(self, password_hash):
+        try:
+            return int(password_hash.split('$')[2])
+        except (IndexError, ValueError) as exc:
+            raise UnknownHashError('Invalid pbkdf2_sha256 hash format') from exc
+
+
+class KAPasswordType(ScalarCoercible, types.TypeDecorator):
+    impl = types.VARBINARY(1024)
+    cache_ok = True
+
+    def __init__(self, max_length=None, onload=None, **kwargs):
+        self.onload = onload
+        self.context_kwargs = kwargs
+        self._context = None
+        self._max_length = max_length or 1024
+
+    @property
+    def context(self):
+        if self._context is None:
+            kwargs = dict(self.context_kwargs)
+            if self.onload is not None:
+                kwargs.update(self.onload(**kwargs))
+            # Delay context construction until first use so Flask config-driven defaults are read
+            # from the active app rather than import time.
+            self._context = PasswordContext(**kwargs)
+        return self._context
+
+    @context.setter
+    def context(self, value):
+        self._context = value
+
+    @property
+    def length(self):
+        return self._max_length
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == 'postgresql':
+            impl = postgresql.BYTEA(self.length)
+        elif dialect.name == 'oracle':
+            impl = oracle.RAW(self.length)
+        elif dialect.name == 'sqlite':
+            impl = sqlite.BLOB(self.length)
+        elif dialect.name == 'mssql':
+            impl = types.VARCHAR(self.length)
+        else:
+            impl = types.VARBINARY(self.length)
+        return dialect.type_descriptor(impl)
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+
+        if isinstance(value, PasswordHash):
+            if value.secret is not None:
+                hashed = self.context.hash(value.secret).encode('utf8')
+            else:
+                hashed = value.hash
+        elif isinstance(value, (str, bytes)):
+            hashed = self.context.hash(value).encode('utf8')
+        else:
+            return value
+
+        # Preserve the existing storage contract: binary on most backends, text on MSSQL.
+        if dialect.name == 'mssql':
+            return hashed.decode('utf8')
+
+        return hashed
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = value.encode('utf8')
+        return PasswordHash(value, self.context)
+
+    def _coerce(self, value):
+        if value is None:
+            return None
+
+        if not isinstance(value, PasswordHash):
+            # Scalar assignment such as ``user.password = 'secret'`` should immediately wrap and
+            # hash the secret so downstream equality checks use the stored-hash semantics.
+            return PasswordHash(self.context.hash(value).encode('utf8'), context=self.context)
+
+        value.context = weakref.proxy(self.context)
+        if value.secret is not None:
+            value.hash = self.context.hash(value.secret).encode('utf8')
+            value.secret = None
+        return value
+
+    @property
+    def python_type(self):
+        return self.impl.type.python_type

--- a/keg_auth/testing.py
+++ b/keg_auth/testing.py
@@ -5,7 +5,6 @@ from urllib.parse import quote
 import arrow
 import flask
 import flask_webtest
-import passlib
 import pytest
 import wrapt
 from blazeutils import randchars
@@ -14,6 +13,7 @@ from keg import current_app
 from keg.db import db
 
 from keg_auth.libs.authenticators import AttemptLimitMixin
+from keg_auth.model.passwords import PasswordContext
 from keg_auth.model.types import AttemptType
 
 has_attempt_skip_reason = 'no attempt model registered in entity registry'
@@ -1235,9 +1235,9 @@ def user_request(wrapped, instance, args, kwargs):
 def with_crypto_context(field, context=None):
     """Wrap a test to use a real cryptographic context for a :class:`KAPasswordType`
 
-    Temporarily assign a :class:`passlib.context.CryptoContext` to a particular entity column.
+    Temporarily assign a password context to a particular entity column.
 
-    :param context (optional): :class:`passlib.context.CryptoContext` to use for this test. The
+    :param context (optional): password context to use for this test. The
         default value is `keg_auth.core.DEFAULT_CRYPTO_SCHEMES`.
 
     .. NOTE:
@@ -1251,7 +1251,7 @@ def with_crypto_context(field, context=None):
 
         import bcrypt
 
-        bcrypt_context = passlib.context.CryptContext(scheme=['bcrypt'])
+        bcrypt_context = PasswordContext(schemes=['bcrypt'])
 
         @with_crypto_context(ents.User.password, context=bcrypt_context)
         def test_with_real_context():
@@ -1264,13 +1264,13 @@ def with_crypto_context(field, context=None):
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
         prev_context = field.type.context
-        field.type.context = (
-            context or passlib.context.CryptContext(schemes=keg_auth.core.DEFAULT_CRYPTO_SCHEMES)
-        )
-
-        wrapped(*args, **kwargs)
-
-        field.type.context = prev_context
+        try:
+            field.type.context = (
+                context or PasswordContext(schemes=keg_auth.core.DEFAULT_CRYPTO_SCHEMES)
+            )
+            return wrapped(*args, **kwargs)
+        finally:
+            field.type.context = prev_context
 
     return wrapper
 

--- a/keg_auth/tests/test_authenticators.py
+++ b/keg_auth/tests/test_authenticators.py
@@ -8,10 +8,10 @@ try:
     import ldap
 except ImportError:
     ldap = None
-import passlib
 import pytest
 
 from keg_auth.libs import authenticators as auth, get_domain_from_email
+from keg_auth.model.passwords import UnknownHashError
 from keg_auth.tests.utils import oauth_profile
 from keg_auth_ta.model.entities import User, UserNoEmail
 
@@ -37,15 +37,12 @@ class TestKegAuthenticator:
         assert e_info.value.user is user
 
     def test_user_unknown_hash(self):
-        # Tough to test the real-world case here, because to run the test suite more quickly,
-        # we use plaintext passwords. The hash error only comes into play with something more
-        # interesting for passlib to use, but there does not seem to be good or clean way to
-        # mock that in later.
-        # So, we'll mock the comparator.
+        # Most tests use plaintext hashing for speed, so mock the comparator to exercise the
+        # unknown-hash path.
         user = User.fake()
         authenticator = auth.KegAuthenticator(app=flask.current_app)
         with mock.patch.object(user.password, '__eq__', autospec=True, spec_set=True) as m_eq:
-            m_eq.side_effect = passlib.exc.UnknownHashError
+            m_eq.side_effect = UnknownHashError
             assert not authenticator.verify_password(user, 'nomatchinghash')
 
     def test_user_verified(self):

--- a/keg_auth/tests/test_model.py
+++ b/keg_auth/tests/test_model.py
@@ -11,9 +11,35 @@ import sqlalchemy as sa
 import bcrypt
 
 from keg_auth.model import InvalidToken, entity_registry, utils
+from keg_auth.model.passwords import PasswordContext
 from keg_auth_ta.model import entities as ents
 from keg_auth.testing import with_crypto_context
 import mock
+
+
+legacy_pbkdf2_context = PasswordContext(schemes=['pbkdf2_sha256'])
+
+
+def test_password_context_legacy_bcrypt_long_secret_no_upgrade():
+    context = PasswordContext(schemes=['bcrypt', 'pbkdf2_sha256'])
+    raw_password = 'a' * 100
+    legacy_hash = bcrypt.hashpw(raw_password[:72].encode(), bcrypt.gensalt()).decode()
+
+    valid, new_hash = context.verify_and_update(raw_password, legacy_hash)
+
+    assert valid
+    assert new_hash is None
+
+
+def test_password_context_legacy_pbkdf2_is_upgraded():
+    context = PasswordContext(schemes=['bcrypt', 'pbkdf2_sha256'])
+    raw_password = 'abc123'
+    legacy_hash = legacy_pbkdf2_context.hash(raw_password)
+
+    valid, new_hash = context.verify_and_update(raw_password, legacy_hash)
+
+    assert valid
+    assert new_hash.startswith('$2')
 
 
 class TestUserTokenMixin(object):
@@ -55,6 +81,15 @@ class TestUserTokenMixin(object):
         uwt = ents.UserWithToken.fake(token=raw)
         assert uwt.verify_token(test) is result
 
+    @with_crypto_context(ents.UserWithToken.token)
+    def test_verify_token_legacy_pbkdf2(self):
+        raw_token = '1234'
+        uwt = ents.UserWithToken.fake(token=raw_token)
+        uwt.token.hash = legacy_pbkdf2_context.hash(raw_token).encode()
+
+        assert uwt.verify_token(raw_token)
+        assert uwt.token.hash.decode().startswith('$pbkdf2-sha256$')
+
     def test_generate_api_token(self):
         u1 = ents.UserWithToken.fake()
         raw_token = u1.generate_api_token()
@@ -62,7 +97,8 @@ class TestUserTokenMixin(object):
         raw_email, token = raw_token.split('.')
         real_email = base64.urlsafe_b64decode(raw_email.encode()).decode()
 
-        assert (real_email, token) == (u1.email, u1.token.hash.decode())
+        assert real_email == u1.email
+        assert u1.verify_token(token)
 
     def test_get_user_for_api_token_happy_path(self):
         u1 = ents.UserWithToken.fake(email='test@test.com', token='1234')

--- a/keg_auth_ta/config.py
+++ b/keg_auth_ta/config.py
@@ -26,7 +26,7 @@ class DefaultProfile(object):
 
 class TestProfile(object):
     # Make tests faster
-    PASSLIB_CRYPTCONTEXT_KWARGS = dict(schemes=['plaintext'])
+    KEGAUTH_PASSWORD_CONTEXT_KWARGS = dict(schemes=['plaintext'])
 
     MAIL_DEFAULT_SENDER = 'sender@example.com'
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Keg>=0.11.0',
         'KegElements>=0.9.0',
         'inflect',
-        'passlib',
         'shortuuid',
         'webgrid>=0.4.13',
     ],

--- a/stable-requirements.txt
+++ b/stable-requirements.txt
@@ -47,7 +47,6 @@ mdurl==0.1.2
 mock==5.2.0
 more-itertools==10.7.0
 packaging==25.0
-passlib==1.7.4
 platformdirs==4.3.8
 pluggy==1.6.0
 psycopg==3.2.9


### PR DESCRIPTION
- sautils PasswordType replaced entirely
- supports the same set of default hash types
  - config still accepts the passlib setting, but introduces a KA-specific setting name that can be used instead.
- possible BC break: if using non-default hash types, these are not currently supported
  - this is an edge case, but should affect the version number in release
- bcrypt 5+ refuses input > 72 bytes, where earlier versions truncated silently. keg-auth will continue to compare those hashes as-is to preserve backward compatibility
  - stored hashes are left unchanged in this case, because we cannot guarantee that the input > 72 bytes is correct according to the originally-input password

fixes #190